### PR TITLE
Replace DAO objects with Data Providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 api
 bin/api
+.idea/

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ docker build -t algoristas-api .
 ```
 
 Followed by:
-`docker run -p 8080:8080 algoristas-api``
+```
+docker run -p 8080:8080 algoristas-api
 ```
 
-This last command will run the application inside the container and will expose the port 8080. You call test the API by querying your localhost at 8080.
+This last command will run the application inside the container and will expose the port 8080. You can test the API by querying localhost at 8080.
 
 ```
 curl localhost:8080/v1/results

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 func main() {
 	log.Println("Listening at :8080...")
 	http.ListenAndServe(":8080", router.Wire(router.Dependencies{
-		StandingsDAO: standings.NewStandingsDAO(),
-		ResultsDAO:   results.NewResultsDAO(),
-		ProblemsDAO:  problems.NewProblemsDAO(),
+		StandingsDataProvider: standings.NewDataProvider(),
+		ResultsDataProvider:   results.NewDataProvider(),
+		ProblemsDataProvider:  problems.NewDataProvider(),
 	}))
 }

--- a/problems/problems.go
+++ b/problems/problems.go
@@ -5,17 +5,17 @@ import (
 	"os"
 )
 
-// ProblemsDAO implements the DAO interface.
-type ProblemsDAO struct {
+// DefaultDataProvider implements the DataProvider interface.
+type DefaultDataProvider struct {
 }
 
 // GetSets returns all the problems in the database.
-func (t *ProblemsDAO) GetSets() ([]byte, error) {
+func (t *DefaultDataProvider) GetSets() ([]byte, error) {
 	fileName := os.Getenv("APP_ROOT") + "/problems/fixtures/problemsets.json"
 	return ioutil.ReadFile(fileName)
 }
 
-// NewProblemsDAO returns a new object that implemts the DAO interface.
-func NewProblemsDAO() DAO {
-	return &ProblemsDAO{}
+// NewDataProvider returns a new DataProvider instance.
+func NewDataProvider() DataProvider {
+	return &DefaultDataProvider{}
 }

--- a/problems/problems_controller.go
+++ b/problems/problems_controller.go
@@ -6,15 +6,15 @@ import (
 	"net/http"
 )
 
-// ProblemsController describes controller for requests at /problems/.
-type ProblemsController struct {
-	dao DAO
+// Controller describes controller for requests at /problems/.
+type Controller struct {
+	dataProvider DataProvider
 }
 
 // SetIndex handles /problems/sets endpoint, returns all problems.
-func (t *ProblemsController) SetIndex(w http.ResponseWriter, r *http.Request) {
+func (t *Controller) SetIndex(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	data, err := t.dao.GetSets()
+	data, err := t.dataProvider.GetSets()
 	if err != nil {
 		log.Printf("Failed to retrieve results: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -25,9 +25,9 @@ func (t *ProblemsController) SetIndex(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
-// NewController returns a new initialized ProblemsController.
-func NewController(problemsDAO DAO) *ProblemsController {
-	return &ProblemsController{
-		dao: problemsDAO,
+// NewController returns a new initialized Controller.
+func NewController(datProvider DataProvider) *Controller {
+	return &Controller{
+		dataProvider: datProvider,
 	}
 }

--- a/problems/problems_dao.go
+++ b/problems/problems_dao.go
@@ -1,6 +1,0 @@
-package problems
-
-// DAO defines Data Access Object for problems.
-type DAO interface {
-	GetSets() ([]byte, error)
-}

--- a/problems/problems_data_provider.go
+++ b/problems/problems_data_provider.go
@@ -1,0 +1,6 @@
+package problems
+
+// DataProvider defines data API for problems.
+type DataProvider interface {
+	GetSets() ([]byte, error)
+}

--- a/problems/problems_test.go
+++ b/problems/problems_test.go
@@ -12,16 +12,16 @@ import (
 	"github.com/algoristas/api/router"
 )
 
-type DAOStub struct {
+type StubbedDataProvider struct {
 }
 
-func (t *DAOStub) GetSets() ([]byte, error) {
+func (t *StubbedDataProvider) GetSets() ([]byte, error) {
 	return []byte(`{"weeks":[]}`), nil
 }
 
 var _ = Describe("Problems", func() {
 	var ts = httptest.NewServer(router.Wire(router.Dependencies{
-		ProblemsDAO: &DAOStub{},
+		ProblemsDataProvider: &StubbedDataProvider{},
 	}))
 
 	It("returns problem list", func() {

--- a/results/results.go
+++ b/results/results.go
@@ -5,16 +5,16 @@ import (
 	"os"
 )
 
-// ResultsDAO implements the DAO interface.
-type ResultsDAO struct{}
+// DefaultDataProvider implements the DataProvider interface.
+type DefaultDataProvider struct{}
 
 // GetResults retrieves all contests results.
-func (t *ResultsDAO) GetResults() ([]byte, error) {
+func (t *DefaultDataProvider) GetResults() ([]byte, error) {
 	fileName := os.Getenv("APP_ROOT") + "/results/fixtures/results.json"
 	return ioutil.ReadFile(fileName)
 }
 
-// NewResultsDAO returns a new object that implements the DAO interface.
-func NewResultsDAO() DAO {
-	return &ResultsDAO{}
+// NewDataProvider returns a new DataProvider instance.
+func NewDataProvider() DataProvider {
+	return &DefaultDataProvider{}
 }

--- a/results/results_controller.go
+++ b/results/results_controller.go
@@ -6,15 +6,15 @@ import (
 	"net/http"
 )
 
-// ResultsController describes controller for requests at /results/.
-type ResultsController struct {
-	dao DAO
+// Controller describes controller for requests at /results/.
+type Controller struct {
+	dataProvider DataProvider
 }
 
 // Index handles /results/ endpoint, returns all results.
-func (t *ResultsController) Index(w http.ResponseWriter, r *http.Request) {
+func (t *Controller) Index(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	data, err := t.dao.GetResults()
+	data, err := t.dataProvider.GetResults()
 	if err != nil {
 		log.Printf("Failed to retrieve results: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -25,9 +25,9 @@ func (t *ResultsController) Index(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
-// NewController returns an initialized ResultsController.
-func NewController(resultsDAO DAO) *ResultsController {
-	return &ResultsController{
-		dao: resultsDAO,
+// NewController returns an initialized Controller.
+func NewController(dataProvider DataProvider) *Controller {
+	return &Controller{
+		dataProvider: dataProvider,
 	}
 }

--- a/results/results_dao.go
+++ b/results/results_dao.go
@@ -1,6 +1,0 @@
-package results
-
-// DAO defines Data Access Object for results.
-type DAO interface {
-	GetResults() ([]byte, error)
-}

--- a/results/results_data_provider.go
+++ b/results/results_data_provider.go
@@ -1,0 +1,6 @@
+package results
+
+// DataProvider defines data API for results.
+type DataProvider interface {
+	GetResults() ([]byte, error)
+}

--- a/results/results_test.go
+++ b/results/results_test.go
@@ -10,16 +10,16 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-type DAOStub struct {
+type StubbedDataProvider struct {
 }
 
-func (t *DAOStub) GetResults() ([]byte, error) {
+func (t *StubbedDataProvider) GetResults() ([]byte, error) {
 	return []byte(`{"users":[]}`), nil
 }
 
 var _ = Describe("Results", func() {
 	var ts = httptest.NewServer(router.Wire(router.Dependencies{
-		ResultsDAO: &DAOStub{},
+		ResultsDataProvider: &StubbedDataProvider{},
 	}))
 
 	It("should return results", func() {

--- a/router/wire.go
+++ b/router/wire.go
@@ -12,9 +12,9 @@ import (
 
 // Dependencies contains every dependency used by the application.
 type Dependencies struct {
-	StandingsDAO standings.DAO
-	ProblemsDAO  problems.DAO
-	ResultsDAO   results.DAO
+	StandingsDataProvider standings.DataProvider
+	ProblemsDataProvider  problems.DataProvider
+	ResultsDataProvider   results.DataProvider
 }
 
 // Wire returns an http.Handler with all the API endpoints configured using the provided
@@ -22,13 +22,13 @@ type Dependencies struct {
 func Wire(deps Dependencies) http.Handler {
 	r := mux.NewRouter()
 
-	standingsController := standings.NewController(deps.StandingsDAO)
+	standingsController := standings.NewController(deps.StandingsDataProvider)
 	r.HandleFunc("/v1/standings", standingsController.Index)
 
-	resultsController := results.NewController(deps.ResultsDAO)
+	resultsController := results.NewController(deps.ResultsDataProvider)
 	r.HandleFunc("/v1/results", resultsController.Index)
 
-	problemsController := problems.NewController(deps.ProblemsDAO)
+	problemsController := problems.NewController(deps.ProblemsDataProvider)
 	r.HandleFunc("/v1/problems/sets", problemsController.SetIndex)
 	return r
 }

--- a/standings/standings.go
+++ b/standings/standings.go
@@ -5,16 +5,16 @@ import (
 	"os"
 )
 
-// StandingDAO implements DAO interface.
-type StandingsDAO struct{}
+// DefaultDataProvider implements DataProvider interface.
+type DefaultDataProvider struct{}
 
 // GetStandings retrieves the standings for all contestants up to this moment.
-func (t *StandingsDAO) GetStandings() ([]byte, error) {
+func (t *DefaultDataProvider) GetStandings() ([]byte, error) {
 	fileName := os.Getenv("APP_ROOT") + "/standings/fixtures/standings.json"
 	return ioutil.ReadFile(fileName)
 }
 
-// NewStandingsDAO returns a new object that implements the DAO interface.
-func NewStandingsDAO() DAO {
-	return &StandingsDAO{}
+// NewDataProvider returns a new DataProvider instance.
+func NewDataProvider() DataProvider {
+	return &DefaultDataProvider{}
 }

--- a/standings/standings_controller.go
+++ b/standings/standings_controller.go
@@ -5,15 +5,15 @@ import (
 	"net/http"
 )
 
-// StandingsController describes controller for requests at /standings/.
-type StandingsController struct {
-	dao DAO
+// Controller describes controller for requests at /standings/.
+type Controller struct {
+	dataProvider DataProvider
 }
 
 // Index handles /standings endpoint, returns the list of standings.
-func (t *StandingsController) Index(w http.ResponseWriter, r *http.Request) {
+func (t *Controller) Index(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	data, err := t.dao.GetStandings()
+	data, err := t.dataProvider.GetStandings()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, `{"status": 500, "message": "Failed to retrieve data"}`)
@@ -23,9 +23,9 @@ func (t *StandingsController) Index(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
-// NewController returns an initialized StandingsController.
-func NewController(standingsDAO DAO) *StandingsController {
-	return &StandingsController{
-		dao: standingsDAO,
+// NewController returns an initialized Controller.
+func NewController(dataProvider DataProvider) *Controller {
+	return &Controller{
+		dataProvider: dataProvider,
 	}
 }

--- a/standings/standings_dao.go
+++ b/standings/standings_dao.go
@@ -1,6 +1,0 @@
-package standings
-
-// DAO defines Data Access Object for standings.
-type DAO interface {
-	GetStandings() ([]byte, error)
-}

--- a/standings/standings_data_provider.go
+++ b/standings/standings_data_provider.go
@@ -1,0 +1,6 @@
+package standings
+
+// DataProvider defines data API for standings.
+type DataProvider interface {
+	GetStandings() ([]byte, error)
+}

--- a/standings/standings_test.go
+++ b/standings/standings_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/algoristas/api/router"
 )
 
-type DAOStub struct{}
+type StubbedDataProvider struct{}
 
-func (t *DAOStub) GetStandings() ([]byte, error) {
+func (t *StubbedDataProvider) GetStandings() ([]byte, error) {
 	return []byte(`{"users":[]}`), nil
 }
 
 var _ = Describe("Standings", func() {
 	var ts = httptest.NewServer(router.Wire(router.Dependencies{
-		StandingsDAO: &DAOStub{},
+		StandingsDataProvider: &StubbedDataProvider{},
 	}))
 
 	It("should return standings data", func() {


### PR DESCRIPTION
Both DAO and Data Providers achieve the same result, they are just
interfaces to our data sources, it's just that I don't want to use the
DAO acronym everywhere, and Data Provider sounds more intuitive, IMHO.

I also renamed a few files, but all in all the functionality remains the
same.

Ah, and I fixed the README, the markdown for the command examples was
wrong.