### PR TITLE
Implement users controller

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -13,6 +13,7 @@ function unit_test() {
     ginkgo problems/
     ginkgo standings/
     ginkgo results/
+    ginkgo users/
 }
 
 function run() {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/algoristas/api/results"
 	"github.com/algoristas/api/router"
 	"github.com/algoristas/api/standings"
+	"github.com/algoristas/api/users"
 )
 
 func main() {
@@ -16,5 +17,6 @@ func main() {
 		StandingsDataProvider: standings.NewDataProvider(),
 		ResultsDataProvider:   results.NewDataProvider(),
 		ProblemsDataProvider:  problems.NewDataProvider(),
+		UsersDataProvider:     users.NewDataProvider(),
 	}))
 }

--- a/problems/problems_controller.go
+++ b/problems/problems_controller.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/julienschmidt/httprouter"
 )
 
 // Controller describes controller for requests at /problems/.
@@ -12,7 +14,7 @@ type Controller struct {
 }
 
 // SetIndex handles /problems/sets endpoint, returns all problems.
-func (t *Controller) SetIndex(w http.ResponseWriter, r *http.Request) {
+func (t *Controller) SetIndex(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.Header().Set("Content-Type", "application/json")
 	data, err := t.dataProvider.GetSets()
 	if err != nil {

--- a/results/results_controller.go
+++ b/results/results_controller.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+
+	"github.com/julienschmidt/httprouter"
 )
 
 // Controller describes controller for requests at /results/.
@@ -12,7 +14,7 @@ type Controller struct {
 }
 
 // Index handles /results/ endpoint, returns all results.
-func (t *Controller) Index(w http.ResponseWriter, r *http.Request) {
+func (t *Controller) Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.Header().Set("Content-Type", "application/json")
 	data, err := t.dataProvider.GetResults()
 	if err != nil {

--- a/router/wire.go
+++ b/router/wire.go
@@ -3,11 +3,12 @@ package router
 import (
 	"net/http"
 
-	"github.com/gorilla/mux"
+	"github.com/julienschmidt/httprouter"
 
 	"github.com/algoristas/api/problems"
 	"github.com/algoristas/api/results"
 	"github.com/algoristas/api/standings"
+	"github.com/algoristas/api/users"
 )
 
 // Dependencies contains every dependency used by the application.
@@ -15,20 +16,24 @@ type Dependencies struct {
 	StandingsDataProvider standings.DataProvider
 	ProblemsDataProvider  problems.DataProvider
 	ResultsDataProvider   results.DataProvider
+	UsersDataProvider     users.DataProvider
 }
 
 // Wire returns an http.Handler with all the API endpoints configured using the provided
 // dependencies.
 func Wire(deps Dependencies) http.Handler {
-	r := mux.NewRouter()
+	r := httprouter.New()
 
 	standingsController := standings.NewController(deps.StandingsDataProvider)
-	r.HandleFunc("/v1/standings", standingsController.Index)
+	r.GET("/v1/standings", standingsController.Index)
 
 	resultsController := results.NewController(deps.ResultsDataProvider)
-	r.HandleFunc("/v1/results", resultsController.Index)
+	r.GET("/v1/results", resultsController.Index)
 
 	problemsController := problems.NewController(deps.ProblemsDataProvider)
-	r.HandleFunc("/v1/problems/sets", problemsController.SetIndex)
+	r.GET("/v1/problems/sets", problemsController.SetIndex)
+
+	usersController := users.NewController(deps.UsersDataProvider)
+	r.GET("/v1/users/:userId", usersController.GetUser)
 	return r
 }

--- a/standings/standings_controller.go
+++ b/standings/standings_controller.go
@@ -3,6 +3,8 @@ package standings
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/julienschmidt/httprouter"
 )
 
 // Controller describes controller for requests at /standings/.
@@ -11,7 +13,7 @@ type Controller struct {
 }
 
 // Index handles /standings endpoint, returns the list of standings.
-func (t *Controller) Index(w http.ResponseWriter, r *http.Request) {
+func (t *Controller) Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.Header().Set("Content-Type", "application/json")
 	data, err := t.dataProvider.GetStandings()
 	if err != nil {

--- a/users/fixtures/users.json
+++ b/users/fixtures/users.json
@@ -1,0 +1,34 @@
+[
+    {
+        "id": 1,
+        "userName": "alice"
+    },
+    {
+        "id": 2,
+        "userName": "bob"
+    },
+    {
+        "id": 3,
+        "userName": "zatarain"
+    },
+    {
+        "id": 99,
+        "userName": "dventura11"
+    },
+    {
+        "id": 4,
+        "userName": "hopkins"
+    },
+    {
+        "id": 13,
+        "userName": "xiddw"
+    },
+    {
+        "id": 7,
+        "userName": "rendon"
+    },
+    {
+        "id": 5,
+        "userName": "ulisesmdzmtz"
+    }
+]

--- a/users/users.go
+++ b/users/users.go
@@ -1,0 +1,69 @@
+package users
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+)
+
+var ErrNotFound = errors.New("User not found")
+
+// User describes a user.
+type User struct {
+	ID       uint   `json:"id"`
+	UserName string `json:"userName"`
+}
+
+// DefaultDataProvider implements the DataProvider interface.
+type DefaultDataProvider struct{}
+
+// FindUserByID finds user by its ID, returns error if the user does not exist
+// or something goes wrong retrieving the user.
+func (t *DefaultDataProvider) FindUserByID(id uint) (*User, error) {
+	users, err := retrieveUsers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, user := range users {
+		if user.ID == id {
+			return &user, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+// FindUserByUserName finds user by its user name, return error if the user does
+// not exist or something goes wrong retrieving the user.
+func (t *DefaultDataProvider) FindUserByUserName(userName string) (*User, error) {
+	users, err := retrieveUsers()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, user := range users {
+		if user.UserName == userName {
+			return &user, nil
+		}
+	}
+	return nil, ErrNotFound
+}
+
+// retrieveUsers retrieves users from our database (a file for now).
+func retrieveUsers() ([]User, error) {
+	fileName := os.Getenv("APP_ROOT") + "/users/fixtures/users.json"
+	data, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	var users []User
+	err = json.Unmarshal(data, &users)
+	return users, err
+}
+
+// NewDataProvider returns a new instance of DataProvider.
+func NewDataProvider() DataProvider {
+	return &DefaultDataProvider{}
+}

--- a/users/users_controller.go
+++ b/users/users_controller.go
@@ -1,0 +1,82 @@
+package users
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"encoding/json"
+	"regexp"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+var numberRegexp = regexp.MustCompile(`^\d+$`)
+
+// Controller describes controller for requests at /users/.
+type Controller struct {
+	usersDataProvider DataProvider
+}
+
+// GetUser handles the /users/:userId endpoint.
+func (t *Controller) GetUser(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
+	userID := params.ByName("userId")
+
+	var user *User
+	var userErr error
+
+	if numberRegexp.MatchString(userID) {
+		id, err := strconv.ParseInt(userID, 10, 32)
+		if err != nil {
+			log.Printf("Invalid ID (%s): %s", userID, err)
+			badRequest(w, "Invalid ID")
+			return
+		}
+		user, userErr = t.usersDataProvider.FindUserByID(uint(id))
+	} else {
+		user, userErr = t.usersDataProvider.FindUserByUserName(userID)
+	}
+
+	if userErr != nil {
+		if userErr == ErrNotFound {
+			log.Printf("User not found: %s", userID)
+			userNotFound(w, "User not found")
+			return
+		}
+		log.Printf("Failed to retrieve user: %s", userErr)
+		internalServerError(w, "Internal Server Error")
+		return
+	}
+
+	data, err := json.Marshal(user)
+	if err != nil {
+		log.Printf("Failed to serialize response: %s", err)
+		internalServerError(w, "Failed to generate response")
+		return
+	}
+	fmt.Fprintf(w, "%s", data)
+}
+
+// NewController returns an initialized Controller.
+func NewController(userDataProvider DataProvider) *Controller {
+	return &Controller{
+		usersDataProvider: userDataProvider,
+	}
+}
+
+func internalServerError(w http.ResponseWriter, message string) {
+	w.WriteHeader(http.StatusInternalServerError)
+	fmt.Fprintf(w, `{"status": 500, "message": "%s"}`, message)
+}
+
+func userNotFound(w http.ResponseWriter, message string) {
+	w.WriteHeader(http.StatusNotFound)
+	fmt.Fprintf(w, `{"status": 404, "message": "%s"}`, message)
+}
+
+func badRequest(w http.ResponseWriter, message string) {
+	w.WriteHeader(http.StatusBadRequest)
+	fmt.Fprintf(w, `{"status": 400, "message": "%s"}`, message)
+}

--- a/users/users_controller.go
+++ b/users/users_controller.go
@@ -28,7 +28,7 @@ func (t *Controller) GetUser(w http.ResponseWriter, r *http.Request, params http
 	var userErr error
 
 	if numberRegexp.MatchString(userID) {
-		id, err := strconv.ParseInt(userID, 10, 32)
+		id, err := strconv.Atoi(userID)
 		if err != nil {
 			log.Printf("Invalid ID (%s): %s", userID, err)
 			badRequest(w, "Invalid ID")

--- a/users/users_data_provider.go
+++ b/users/users_data_provider.go
@@ -1,0 +1,7 @@
+package users
+
+// DataProvider defines the data API for users.
+type DataProvider interface {
+	FindUserByID(id uint) (*User, error)
+	FindUserByUserName(userName string) (*User, error)
+}

--- a/users/users_suite_test.go
+++ b/users/users_suite_test.go
@@ -1,0 +1,13 @@
+package users_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestUsers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Users Suite")
+}

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -1,0 +1,128 @@
+package users_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/algoristas/api/router"
+	"github.com/algoristas/api/users"
+)
+
+type ErrorResponse struct {
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+}
+
+var usersDataProvider = users.NewDataProvider()
+
+// StubbedDataProvider implements users.DataProvider to test uncommon scenarios.
+type StubbedDataProvider struct{}
+
+func (t *StubbedDataProvider) FindUserByID(id uint) (*users.User, error) {
+	return nil, errors.New("Something went wrong!")
+}
+
+func (t *StubbedDataProvider) FindUserByUserName(userName string) (*users.User, error) {
+	return nil, errors.New("Something went wrong!")
+}
+
+var _ = Describe("Users", func() {
+	Describe("Find user by ID", func() {
+		It("should return user if it exists", func() {
+			user, err := usersDataProvider.FindUserByID(1)
+			Expect(err).To(BeNil())
+			Expect(user.ID).To(Equal(uint(1)))
+			Expect(user.UserName).To(Equal("alice"))
+		})
+
+		It("should return error if user does not exist", func() {
+			_, err := usersDataProvider.FindUserByID(11)
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Describe("Find user by user name", func() {
+		It("should return user if it exists", func() {
+			user, err := usersDataProvider.FindUserByUserName("bob")
+			Expect(err).To(BeNil())
+			Expect(user.ID).To(Equal(uint(2)))
+			Expect(user.UserName).To(Equal("bob"))
+		})
+
+		It("should return error if user does not exist", func() {
+			_, err := usersDataProvider.FindUserByUserName("alice_and_bob")
+			Expect(err).NotTo(BeNil())
+		})
+	})
+
+	Describe("Users controller", func() {
+		var ts = httptest.NewServer(router.Wire(router.Dependencies{
+			UsersDataProvider: users.NewDataProvider(),
+		}))
+
+		It("should return error if user does not exist", func() {
+			resp, err := http.Get(ts.URL + "/v1/users/nouser")
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+
+			defer resp.Body.Close()
+			var decoder = json.NewDecoder(resp.Body)
+
+			var errorResponse ErrorResponse
+			Expect(decoder.Decode(&errorResponse)).To(BeNil())
+			Expect(errorResponse.Status).To(Equal(http.StatusNotFound))
+			Expect(errorResponse.Message).To(Equal("User not found"))
+		})
+
+		It("should return user by ID", func() {
+			resp, err := http.Get(ts.URL + "/v1/users/1")
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			defer resp.Body.Close()
+			var decoder = json.NewDecoder(resp.Body)
+
+			var user users.User
+			Expect(decoder.Decode(&user)).To(BeNil())
+			Expect(user.ID).To(Equal(uint(1)))
+			Expect(user.UserName).To(Equal("alice"))
+		})
+
+		It("should return user by user name", func() {
+			resp, err := http.Get(ts.URL + "/v1/users/bob")
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			defer resp.Body.Close()
+			var decoder = json.NewDecoder(resp.Body)
+
+			var user users.User
+			Expect(decoder.Decode(&user)).To(BeNil())
+			Expect(user.ID).To(Equal(uint(2)))
+			Expect(user.UserName).To(Equal("bob"))
+		})
+
+		It("should return internal server error if something goes wrong", func() {
+			var ts = httptest.NewServer(router.Wire(router.Dependencies{
+				UsersDataProvider: &StubbedDataProvider{},
+			}))
+
+			resp, err := http.Get(ts.URL + "/v1/users/bob")
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+
+			defer resp.Body.Close()
+			var decoder = json.NewDecoder(resp.Body)
+
+			var errorResponse ErrorResponse
+			Expect(decoder.Decode(&errorResponse)).To(BeNil())
+			Expect(errorResponse.Status).To(Equal(http.StatusInternalServerError))
+			Expect(errorResponse.Message).To(Equal("Internal Server Error"))
+		})
+	})
+})


### PR DESCRIPTION
In this change I created a controller to handle the /users/{userId}
endpoint, where userId could be a numeric ID or a user name.

I changed the naming convention for parameters from snake_case (user_id)
to camelCase (userId) because our client is written in Javascript and it
uses camelCase.

For now our database is just a file with some users in JSON format.

This change is a needed to implement the "Has user X solved problem Y"
because for that we need users first.