### PR TITLE
Refactor of the code,  better handle of errors, change fields names of JSON response

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ curl -i localhost:8080/v1/standings
 
 # Code Review guidelines
 You can read [Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments) for more info about how to add comments in Go code.
+
+# Contributing
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+
+```
+git pull
+git checkout -b your_branch
+git add *all_files_to_add*
+git commit
+git push origin your_branch
+```
+Then, go to GitHub to make a push request

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ git add *all_files_to_add*
 git commit
 git push origin your_branch
 ```
-Then, go to GitHub to make a push request
+Then, go to GitHub to make a pull request


### PR DESCRIPTION
- Refactor the code to follow the Camel case convention
- Add a function to create a net client connection
- Create constants to symbolize differents timeouts
- Add a condition to manage the error when the response cannot be parse.
- Change fields names to parse the JSON response from the API.